### PR TITLE
Feature/45 deletion routing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,6 +38,7 @@
         "allowTaggedTemplates": true
       }
     ],
+    "import/no-cycle": "off",
     "import/order": "off",
     "import/extensions": "off",
     "import/prefer-default-export": "off",

--- a/public/component/App.js
+++ b/public/component/App.js
@@ -1,16 +1,22 @@
-import Post from './Post/Post.js';
 import Header from './Common/Header.js';
-import PostList from './Home/PostList.js';
+import Main from './Home/Main.js';
+import PostDetail from './Post/PostDetail.js';
 import Writing from './Writing/Writing.js';
 
-const routes = {
-  '/': $parent => new PostList({ $parent }),
-  '/index.html': $parent => new PostList({ $parent }),
-  '/posts': $parent => new Post({ $parent }),
+export const ROUTE_TYPE = {
+  HOME: '/',
+  POSTS: '/posts',
+  WRITING: '/writing',
+};
+
+export const routes = {
+  '/': $parent => new Main({ $parent }),
+  '/index.html': $parent => new Main({ $parent }),
+  '/posts': $parent => new PostDetail({ $parent }),
   '/writing': $parent => new Writing({ $parent }),
 };
 
-export default function App($app) {
+export default function App ($app) {
   this.state = {
     isRoot: false,
   };

--- a/public/component/Common/event/addHeaderEvent.js
+++ b/public/component/Common/event/addHeaderEvent.js
@@ -1,4 +1,4 @@
-import { WritingComponent } from '../../Writing/Writing.js';
+import { ROUTE_TYPE, routes } from '../../App.js';
 
 const addHeaderEvent = $parent => {
   const $navUserWrapper = document.querySelector('.navbar-user-wrapper');
@@ -10,8 +10,8 @@ const addHeaderEvent = $parent => {
   });
 
   $navWritingBtn.addEventListener('click', () => {
-    window.history.pushState({}, '/writing', window.location.origin + '/writing');
-    WritingComponent($parent);
+    window.history.pushState({}, ROUTE_TYPE.WRITING, window.location.origin + ROUTE_TYPE.WRITING);
+    routes[ROUTE_TYPE.WRITING]($parent);
   });
 };
 

--- a/public/component/Home/Main.js
+++ b/public/component/Home/Main.js
@@ -1,10 +1,11 @@
 import addFilter from './event/addFilter.js';
 import addPostListEvent from './event/addPostListEvent.js';
 
-export default function PostList ({ $parent, initialState, onClick }) {
+export default function Main ({ $parent, initialState, onClick }) {
   this.state = initialState;
   this.onClick = onClick;
   this.$target = document.createElement('div');
+  if ($parent.children.length > 1) $parent.removeChild($parent.lastChild);
   $parent.appendChild(this.$target);
 
   this.setState = nextState => {

--- a/public/component/Home/event/addPostListEvent.js
+++ b/public/component/Home/event/addPostListEvent.js
@@ -1,13 +1,12 @@
-import Comment from '../../Post/Post.js';
+import { ROUTE_TYPE, routes } from '../../App.js';
 
-export default function addPostListEvent($parent, $target) {
+export default function addPostListEvent ($parent, $target) {
   const $postList = $target.querySelector('.post-list');
   $postList.addEventListener('click', e => {
     const $li = e.target.closest('.post');
     if (!$li) return;
     const { id } = $li.dataset;
     window.history.pushState({}, `/posts?id=${id}`, window.location.origin + `/posts?id=${id}`);
-    $parent.removeChild($parent.lastChild);
-    new Comment({ $parent, initialState: {} });
+    routes[ROUTE_TYPE.POSTS]($parent);
   });
 }

--- a/public/component/Post/PostDetail.js
+++ b/public/component/Post/PostDetail.js
@@ -1,8 +1,9 @@
-import addEvent from './event/app.js';
+import addPostDetailEvent from './event/addPostDetailEvent.js';
 
-export default function Comment({ $parent, initialState }) {
+export default function PostDetail ({ $parent, initialState }) {
   this.state = initialState;
   this.$target = document.createElement('main');
+  if ($parent.children.length > 1) $parent.removeChild($parent.lastChild);
   $parent.appendChild(this.$target);
 
   this.setState = nextState => {
@@ -49,7 +50,7 @@ export default function Comment({ $parent, initialState }) {
   };
 
   this.addEvent = () => {
-    addEvent();
+    addPostDetailEvent($parent);
   };
 
   this.render();

--- a/public/component/Post/event/addPostDetailEvent.js
+++ b/public/component/Post/event/addPostDetailEvent.js
@@ -1,20 +1,22 @@
-import store from '../postUtils/fetchPost.js';
-import render from '../postUtils/render.js';
+import { ROUTE_TYPE, routes } from '../../App.js';
 
-export default function addEvent() {
+import postStore from '../../../store/post.js';
+import render from '../postUtils/renderPost.js';
+
+export default function addPostDetailEvent ($parent) {
   const $modal = document.querySelector('.modal');
   const $postBox = document.querySelector('.post-box');
   const $commentBox = document.querySelector('.comment-box');
 
   const [id] = [...new URLSearchParams(new URL(window.location.href).search).values()];
 
-  store.getPost(id);
+  postStore.getPost(id);
 
   $postBox.addEventListener('click', ({ target }) => {
     if (!target.matches('.post-box button')) return;
 
     if (target.classList.contains('ended')) {
-      store.endedPost(id);
+      postStore.endedPost(id);
     }
 
     if (target.classList.contains('edit')) {
@@ -36,7 +38,7 @@ export default function addEvent() {
     }
 
     if (target.classList.contains('like')) {
-      store.changeLikeCount(id, target.classList.contains('active'));
+      postStore.changeLikeCount(id, target.classList.contains('active'));
     }
   });
 
@@ -48,8 +50,9 @@ export default function addEvent() {
     }
 
     if (target.classList.contains('apply')) {
-      // 삭제 시 메인으로
-      store.deletePost(id);
+      postStore.deletePost(id);
+      window.history.replaceState({}, ROUTE_TYPE.HOME, window.location.origin + ROUTE_TYPE.HOME);
+      routes[ROUTE_TYPE.HOME]($parent);
     }
   });
 
@@ -60,7 +63,7 @@ export default function addEvent() {
       const content = target.previousElementSibling.value.trim();
       if (!content) return;
 
-      store.uploadComment(id, content);
+      postStore.uploadComment(id, content);
     }
 
     if (target.classList.contains('edit')) {
@@ -82,7 +85,7 @@ export default function addEvent() {
     if (target.classList.contains('cancel')) {
       const $editBtn = target.closest('.comment-content').previousElementSibling.querySelector('.edit');
 
-      store.getPost(id);
+      postStore.getPost(id);
 
       $editBtn.classList.remove('active');
     }
@@ -91,18 +94,13 @@ export default function addEvent() {
       const content = target.parentNode.firstElementChild.value.trim();
       if (!content) return;
 
-      store.editComment(id, target.closest('.comment').dataset.id, content);
+      postStore.editComment(id, target.closest('.comment').dataset.id, content);
     }
 
     if (target.classList.contains('delete')) {
-      store.deleteComment(id, target.closest('.comment').dataset.id);
+      postStore.deleteComment(id, target.closest('.comment').dataset.id);
     }
   });
 
-  store.subscribe(render);
+  postStore.subscribe(render);
 }
-
-// export const PostComponent = ($parent, initialState) => {
-//   $parent.removeChild($parent.lastChild);
-//   new Post({ $parent, initialState });
-// };

--- a/public/component/Post/postUtils/renderPost.js
+++ b/public/component/Post/postUtils/renderPost.js
@@ -1,3 +1,5 @@
+import { ROUTE_TYPE, routes } from '../../App.js';
+
 import { initialFilter } from '../../../store/filter.js';
 
 const formatContent = content => content.replace(/\n/g, '<br>');
@@ -114,7 +116,13 @@ const renderPost = (post, likeActive, authUser) => {
 };
 
 const render = ({ post, likeActive }, authUser) => {
-  renderPost(post, likeActive, authUser);
+  try {
+    if (!post) throw new Error('Data Not Found');
+    renderPost(post, likeActive, authUser);
+  } catch (e) {
+    window.history.replaceState({}, ROUTE_TYPE.HOME, window.location.origin + ROUTE_TYPE.HOME);
+    routes[ROUTE_TYPE.HOME](document.querySelector('#root'));
+  }
 };
 
 export default render;

--- a/public/component/Writing/Writing.js
+++ b/public/component/Writing/Writing.js
@@ -3,6 +3,7 @@ import addWritingEvent from './event/addWritingEvent.js';
 export default function Writing ({ $parent, initialState }) {
   this.state = initialState;
   this.$target = document.createElement('div');
+  if ($parent.children.length > 1) $parent.removeChild($parent.lastChild);
   $parent.appendChild(this.$target);
 
   this.setState = nextState => {
@@ -76,14 +77,9 @@ export default function Writing ({ $parent, initialState }) {
   };
 
   this.addEvent = () => {
-    addWritingEvent(this.$target);
+    addWritingEvent($parent);
   };
 
   this.render();
   this.addEvent();
 }
-
-export const WritingComponent = ($parent, initialState) => {
-  $parent.removeChild($parent.lastChild);
-  new Writing({ $parent, initialState });
-};

--- a/public/component/Writing/event/addWritingEvent.js
+++ b/public/component/Writing/event/addWritingEvent.js
@@ -2,15 +2,15 @@ import client from '../../../api/axios.js';
 import { initialFilter } from '../../../store/filter.js';
 import { todayFormat } from '../../../utils/date.js';
 
-export default function addEventWriting ($target) {
-  const $title = $target.querySelector('.title');
-  const $city = $target.querySelector('.city');
-  const $sports = $target.querySelector('.sports');
-  const $cityList = $target.querySelector('.city-list');
-  const $cityItems = $target.querySelector('.city-items');
-  const $sportsList = $target.querySelector('.sports-list');
-  const $sportsItems = $target.querySelector('.sports-items');
-  const $writeArea = $target.querySelector('.writing-area');
+export default function addEventWriting ($parent) {
+  const $title = $parent.querySelector('.title');
+  const $city = $parent.querySelector('.city');
+  const $sports = $parent.querySelector('.sports');
+  const $cityList = $parent.querySelector('.city-list');
+  const $cityItems = $parent.querySelector('.city-items');
+  const $sportsList = $parent.querySelector('.sports-list');
+  const $sportsItems = $parent.querySelector('.sports-items');
+  const $writeArea = $parent.querySelector('.writing-area');
 
   // post
   const postingSend = async payload => {
@@ -38,7 +38,7 @@ export default function addEventWriting ($target) {
   listCreate(initialFilter.sports, $sportsList);
 
   document.querySelector('.writing-submit').addEventListener('click', () => {
-    const $cityItem = $target.querySelector('.city-item > span');
+    const $cityItem = $parent.querySelector('.city-item > span');
     // 임시 처리
     if ($title.value.trim() === '') {
       alert('제목을 입력해주세요');
@@ -124,21 +124,21 @@ export default function addEventWriting ($target) {
   });
 
   // 선택창 띄우기 - city
-  $target.querySelector('.city-show').addEventListener('click', () => {
+  $parent.querySelector('.city-show').addEventListener('click', () => {
     $city.classList.toggle('active');
   });
   // 선택창 띄우기 - sports
-  $target.querySelector('.sports-show').addEventListener('click', () => {
+  $parent.querySelector('.sports-show').addEventListener('click', () => {
     $sports.classList.toggle('active');
   });
 
   // 전체 삭제 - city
-  $target.querySelector('.city-all-delete').addEventListener('click', () => {
+  $parent.querySelector('.city-all-delete').addEventListener('click', () => {
     $cityItems.innerHTML = '';
   });
 
   // 전체 삭제 - sports
-  $target.querySelector('.sports-all-delete').addEventListener('click', () => {
+  $parent.querySelector('.sports-all-delete').addEventListener('click', () => {
     $sportsItems.innerHTML = '';
   });
 
@@ -147,6 +147,6 @@ export default function addEventWriting ($target) {
     if (!e.target.matches('.one-delete')) return false;
     e.target.parentNode.remove();
   };
-  $target.querySelector('.city-container').addEventListener('click', e => oneDelete(e));
-  $target.querySelector('.sports-container').addEventListener('click', e => oneDelete(e));
+  $parent.querySelector('.city-container').addEventListener('click', e => oneDelete(e));
+  $parent.querySelector('.sports-container').addEventListener('click', e => oneDelete(e));
 }

--- a/public/page/main/post.js
+++ b/public/page/main/post.js
@@ -22,7 +22,7 @@ function getPostElements(data) {
       />
       <p class="post-filter-name">${initialFilter.sports[positionId]}</p>
       </li>
-    `
+    `,
       )
       .join('')}
   </ul>

--- a/public/store/post.js
+++ b/public/store/post.js
@@ -1,4 +1,4 @@
-import { todayFormat } from '../../../utils/date.js';
+import { todayFormat } from '../utils/date.js';
 
 const store = {
   state: {
@@ -8,24 +8,24 @@ const store = {
   // localStorage user
   _authUser: { id: 3, nickname: '토끼' },
   postListeners: [],
-  notify() {
+  notify () {
     console.log('[STATE]', this.state);
     this.postListeners.forEach(listener => listener(this.state, this._authUser));
   },
-  get post() {
+  get post () {
     return this.state.post;
   },
-  set post(newPost) {
+  set post (newPost) {
     this.state.post = newPost;
     this.notify();
   },
-  set likeActive(activeState) {
+  set likeActive (activeState) {
     this.state.likeActive = activeState;
   },
-  get editActive() {
+  get editActive () {
     return this.state.editActive;
   },
-  get authUser() {
+  get authUser () {
     return this._authUser;
   },
 };

--- a/test/test.js
+++ b/test/test.js
@@ -1,1 +1,0 @@
-// git test


### PR DESCRIPTION
## What is this PR? :mag:
- Post Detail Page 내에서 해당 게시글 삭제 시, `routes[ROUTE_TYPE.HOME]($app)`으로 메인 컴포넌트 생성
- history.replaceState를 사용하여 삭제한 페이지로 뒤로가기 막음

```javascript
if (target.classList.contains('apply')) {
  postStore.deletePost(id);
  window.history.replaceState({}, ROUTE_TYPE.HOME, window.location.origin + ROUTE_TYPE.HOME);
  routes[ROUTE_TYPE.HOME]($parent);
}
```


## Changes 👀 
- Post 관련 파일 명칭 변경
  - `app.js -> addPostDetailEvent.js`
  - `render.js -> renderPost.js`
- Post 내 store는 상위 store Directory로 이동``
  - `/public/store/post.js`

- routes에서 url 키를 통해 라우팅 실행
  - 매번 컴포넌트를 불러와서 실행하는 것보다 유지 보수성 높을 것으로 판단
  - 각 컴포넌트가 생성될 때, 부모 노드에서 lastChild 제거 후, 컴포넌트 노드 추가
  
```javascript
export const ROUTE_TYPE = {
  HOME: '/',
  POSTS: '/posts',
  WRITING: '/writing',
};

export const routes = {
  '/': $parent => new Main({ $parent }),
  '/index.html': $parent => new Main({ $parent }),
  '/posts': $parent => new PostDetail({ $parent }),
  '/writing': $parent => new Writing({ $parent }),
};

```

## Screenshots :camera:
https://user-images.githubusercontent.com/62092665/147042983-93398123-11e3-44eb-8814-4b4e947b9c34.mp4




close #45 